### PR TITLE
Make xcall greater

### DIFF
--- a/src/IRTools.jl
+++ b/src/IRTools.jl
@@ -39,7 +39,7 @@ let exports = :[
       IR, Block, BasicBlock, Variable, Statement, Branch, Pipe, CFG, Slot, branch, var, stmt, arguments, argtypes,
       branches, undef, unreachable, isreturn, isconditional, block!, deleteblock!, branch!, argument!, return!,
       canbranch, returnvalue, returntype, emptyargs!, deletearg!, block, blocks, successors, predecessors,
-      xcall, exprtype, exprline, isexpr, insertafter!, explicitbranch!, prewalk, postwalk,
+      XCall, xcall, exprtype, exprline, isexpr, insertafter!, explicitbranch!, prewalk, postwalk,
       prewalk!, postwalk!, finish, substitute!, substitute,
       # Passes/Analysis
       definitions, usages, dominators, domtree, domorder, domorder!, renumber,

--- a/src/ir/utils.jl
+++ b/src/ir/utils.jl
@@ -1,4 +1,4 @@
-import Base: map, map!
+import Base: getproperty, map, map!
 import Core.Compiler: PhiNode, PiNode, ssamap, userefs
 import MacroTools: walk
 
@@ -76,6 +76,11 @@ end
 
 @eval begin
     # since var"#module#" does not work in pre-1.3
+    
+    """
+    `ModCall.bla(args...; kwargs...)` is a hack to produce the properly namespaced expression for
+    Mod.bla(args...; kwargs...), equivalent to `xcall(Mod, :bla, args...)`.
+    """
     struct XCall
         $(Symbol("#module#"))::Module
     end
@@ -91,10 +96,6 @@ function getproperty(x::XCall, name::Symbol)
 end
 
 
-"""
-`BaseCall.<bla>(args...; kwargs...)` is a hack to produce the properly namespaced expression for
-BaseCall.<bla>(args...; kwargs...).
-"""
 const BaseCall = XCall(Base)
 
 

--- a/src/ir/utils.jl
+++ b/src/ir/utils.jl
@@ -9,10 +9,6 @@ walk(x::PhiNode, inner, outer) =
 
 walk(x::PiNode, inner, outer) = outer(PiNode(inner(x.val), x.typ))
 
-xcall(mod::Module, f::Symbol, args...) = Expr(:call, GlobalRef(mod, f), args...)
-xcall(f::Symbol, args...) = xcall(Base, f, args...)
-xcall(f, args...) = Expr(:call, f, args...)
-
 map(f, br::Branch) = Branch(br, condition = f(br.condition), args = f.(br.args))
 
 function map(f, b::BasicBlock)
@@ -76,3 +72,55 @@ function exprline(ir::IR, x::Variable)
   i > 0 || return
   get(ir.lines, ir[x].line, nothing)
 end
+
+
+@eval begin
+    # since var"#module#" does not work in pre-1.3
+    struct XCall
+        $(Symbol("#module#"))::Module
+    end
+end
+
+function getproperty(x::XCall, name::Symbol)
+    mod = getfield(x, Symbol("#module#"))
+    if name === Symbol("#module#")
+        return mod
+    else
+        return (args...; kwargs...) -> xcall(mod, name, args...; kwargs...)
+    end
+end
+
+
+"""
+`BaseCall.<bla>(args...; kwargs...)` is a hack to produce the properly namespaced expression for
+BaseCall.<bla>(args...; kwargs...).
+"""
+const BaseCall = XCall(Base)
+
+
+function xcall(_f, args...; kwargs...)
+    if isempty(kwargs)
+        Expr(:call, _f, args...)
+    else
+        keys = QuoteNode[]
+        values = Any[]
+        for (k, v) in kwargs
+            push!(keys, QuoteNode(k))
+            push!(values, v)
+        end
+
+        _call(args...) = Expr(:call, args...)
+        _apply_type = GlobalRef(Core, :apply_type)
+        _NamedTuple = GlobalRef(Core, :NamedTuple)
+        _tuple = GlobalRef(Core, :tuple)
+        _kwfunc = GlobalRef(Core, :kwfunc)
+        
+        _namedtuple = _call(_apply_type, _NamedTuple, _call(_tuple, keys...))
+        _kws = _call(_namedtuple, _call(_tuple, values...))
+        return _call(_call(_kwfunc, _f), _kws, _f, args...)
+    end
+end
+
+xcall(mod::Module, f::Symbol, args...; kwargs...) =
+    xcall(GlobalRef(mod, f), args...; kwargs...)
+xcall(f::Symbol, args...; kwargs...) = xcall(GlobalRef(Base, f), args...; kwargs...)

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -151,3 +151,16 @@ mul = func(ir)
 end
 
 @test ir_add(5, 2) == 7
+
+
+const LACall = XCall(LinearAlgebra)
+ir = IR()
+x = argument!(ir)
+y = push!(ir, LACall.lu(x, check = true))
+z = push!(ir, BaseCall.getproperty(y, QuoteNode(:L)))
+w = push!(ir, BaseCall.getindex(z, 1:2, 2:2))
+d = push!(ir, :(2))
+return!(ir, BaseCall.dropdims(w, dims = d))
+
+R = [1 0; 0 1]
+@test IRTools.evalir(ir, R) == [0, 1]


### PR DESCRIPTION
Two separate additions, really:

- `xcall` can take keyword arguments (if there aren't any, it just does the old thing).
- A helper thing I use all the time: the `XCall` struct, such that `const MyLiBCall = XCall(MyLib); MyLibCall.f(args...)` is equivalent to `xcall(MyLib, :f, args...)` (simply by using `getproperty` returning a closure).

This should be completely downwards compatible, though.