### PR TITLE
Compile-time hacks

### DIFF
--- a/src/IRTools.jl
+++ b/src/IRTools.jl
@@ -4,6 +4,11 @@ export @code_ir
 
 module Inner
 
+  @nospecialize
+  @static if VERSION > v"1.5.0-"
+    Base.Experimental.@optlevel 0
+  end
+
   using MacroTools
   using MacroTools: @q, prewalk, postwalk
   import ..IRTools


### PR DESCRIPTION
Avoid over-specialising IRTools code. Should result in lower compile times for dependencies.

`IRCode(::TypedMeta)` is removed since `just_construct_ssa` was removed from Base, and we don't use this method anyway.