### PR TITLE
Fix evaluation with module in func()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 docs/build
 .DS_Store
+.vscode/
 
 Manifest.toml

--- a/src/eval.jl
+++ b/src/eval.jl
@@ -15,9 +15,9 @@ function build_codeinfo(ir::IR)
 end
 
 function func(m::Module, ir::IR)
-  @eval @generated function $(gensym())($([Symbol(:arg, i) for i = 1:length(arguments(ir))]...))
-    return build_codeinfo($ir)
-  end
+  @eval m (@generated function $(gensym())($([Symbol(:arg, i) for i = 1:length(arguments(ir))]...))
+    return $build_codeinfo($ir)
+  end)
 end
 
 func(ir::IR) = func(Main, ir)


### PR DESCRIPTION
While trying to construct a function from IR in my package, I got an error:

>  Evaluation into the closed module `Inner` breaks incremental compilation because the side effects will not be permanent. This is likely due to some other module mutating `Inner` with eval during precompilation - don't do this.

After some investigation, I found out that `IRTools.func(m, ir)` takes module argument, but doesn't actually use it. This PR fixes it. 

I wasn't able to reproduce this issue in tests In reasonable time to prevent future regressions, but I hope the change still makes sense.
