### PR TITLE
make call to get IR object more direct

### DIFF
--- a/src/eval.jl
+++ b/src/eval.jl
@@ -1,10 +1,11 @@
 using Base: invokelatest
 
 dummy() = return
+const dummy_m = which(dummy, Tuple{})
 
 function build_codeinfo(ir::IR)
   ir = copy(ir)
-  ci = code_lowered(dummy, Tuple{})[1]
+  ci = Base.uncompressed_ir(dummy_m)
   ci.inlineable = true
   for arg in arguments(ir)
     push!(ci.slotnames, Symbol(""))


### PR DESCRIPTION
Avoids the world age problem with `code_lowered`