### PR TITLE
Use Core.throw("unreachable") for unreachables instead of `ReturnNode()`

### DIFF
--- a/src/ir/wrap.jl
+++ b/src/ir/wrap.jl
@@ -38,7 +38,7 @@ function IRCode(ir::IR)
         x = get(defs, br.args[1], br.args[1]) |> unvars
         push!(stmts, ReturnNode(x))
       elseif br == unreachable
-        push!(stmts, ReturnNode())
+        push!(stmts, Expr(:call, GlobalRef(Core, :throw), "unreachable"))
       elseif br.condition == nothing
         push!(stmts, GotoNode(br.block))
       else

--- a/src/ir/wrap.jl
+++ b/src/ir/wrap.jl
@@ -38,7 +38,11 @@ function IRCode(ir::IR)
         x = get(defs, br.args[1], br.args[1]) |> unvars
         push!(stmts, ReturnNode(x))
       elseif br == unreachable
-        push!(stmts, Expr(:call, GlobalRef(Core, :throw), "unreachable"))
+        @static if VERSION >= v"1.11.0-DEV.655"
+          push!(stmts, ReturnNode())
+        else
+          push!(stmts, Expr(:call, GlobalRef(Core, :throw), "unreachable"))
+        end
       elseif br.condition == nothing
         push!(stmts, GotoNode(br.block))
       else

--- a/src/ir/wrap.jl
+++ b/src/ir/wrap.jl
@@ -38,7 +38,7 @@ function IRCode(ir::IR)
         x = get(defs, br.args[1], br.args[1]) |> unvars
         push!(stmts, ReturnNode(x))
       elseif br == unreachable
-        @static if VERSION >= v"1.11.0-DEV.655"
+        @static if VERSION >= v"1.10"
           push!(stmts, ReturnNode())
         else
           push!(stmts, Expr(:call, GlobalRef(Core, :throw), "unreachable"))

--- a/src/reflection/utils.jl
+++ b/src/reflection/utils.jl
@@ -64,7 +64,7 @@ function slots!(ci::CodeInfo)
     end
     if VERSION >= v"1.6.0-DEV.272"
       ci.code[i] = MacroTools.prewalk(ci.code[i]) do x
-        x isa Core.ReturnNode ? Core.ReturnNode(f(x.val)) :
+        x isa Core.ReturnNode ? (isdefined(x,:val) ? Core.ReturnNode(f(x.val)) : x) :
         x isa Core.GotoIfNot ? Core.GotoIfNot(f(x.cond), x.dest) :
         f(x)
       end

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -1,6 +1,7 @@
 using IRTools, MacroTools, InteractiveUtils, Test
 using IRTools: @dynamo, IR, meta, isexpr, xcall, self, insertafter!, recurse!,
-  argument!, return!, func, var, functional
+  argument!, return!, block!, branch!, func, var, functional
+using InteractiveUtils: code_typed
 
 @dynamo roundtrip(a...) = IR(a...)
 
@@ -194,3 +195,19 @@ function f94(x)
 end
 @test f94(1) == 1
 @test passthrough(f94, 1) == 1
+
+@testset "unreachable" begin
+    # 1: (%1)
+    #   return nothing
+    # 2:
+    #   unreachable
+    ir = IR()
+    argument!(ir)
+    return!(ir, nothing)
+    block!(ir)
+    branch!(ir, 0)
+
+    func_ir = IRTools.func(ir)
+    @test (code_typed(func_ir, Tuple{typeof(func_ir)}) |> only
+           isa Pair{Core.CodeInfo,DataType})
+end


### PR DESCRIPTION
It is currently not possible to use `IRTools.unreachable` branches when building irs (see the test which fails with current IRTools).

Indeed, `ReturnNode()` only appears later in the Julia compiler optimization pipeline and is not expected to be part of a lowered piece of code. The Julia compiler throws in [find_ssavalues_uses](https://github.com/JuliaLang/julia/blob/730450c5bb909fa780c233a88f699e0a8290f899/base/compiler/utilities.jl#L393) and [this comment](https://github.com/JuliaLang/julia/blob/730450c5bb909fa780c233a88f699e0a8290f899/base/compiler/utilities.jl#L471-L473) makes me think that it is more supported to throw than to use `ReturnNode()` in untyped ir.
