### PR TITLE
Adjust to EnterNode change

### DIFF
--- a/src/ir/print.jl
+++ b/src/ir/print.jl
@@ -79,6 +79,9 @@ end
 
 function print_stmt(io::IO, ::Val{:enter}, ex)
   print(io, "try #$(ex.args[1])")
+  if length(ex.args) >= 2
+      print(io, " with scope ", ex.args[2])
+  end
 end
 
 function print_stmt(io::IO, ::Val{:leave}, ex)

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -211,3 +211,21 @@ end
     @test (code_typed(func_ir, Tuple{typeof(func_ir)}) |> only
            isa Pair{Core.CodeInfo,DataType})
 end
+
+function f_try_catch(x)
+    y = 0.
+    try
+        y = sqrt(x)
+    catch
+
+    end
+    y
+end
+
+@testset "try/catch" begin
+    ir = @code_ir f_try_catch(1.)
+    @test true
+    fir = func(ir)
+    @test fir(nothing,1.) == 1.
+    @test_broken fir(nothing,-1.) == 1.
+end


### PR DESCRIPTION
the EnterNode struct was added in https://github.com/JuliaLang/julia/pull/52300 This commit adds support for ingesting and exporting CodeInfo with EnterNode but still uses `Expr(:enter)` inside IRTools IR. We may want to switch the representation to `IRTools.EnterNode` similarly to `IRTools.Slot` if more fields are added to the `Core.EnterNode` struct.

This PR should probably not be merged before https://github.com/JuliaLang/julia/pull/52309 which adds the scope field to `EnterNode`.

the broken test is fixed separately by #117.