### PR TITLE
Adapt to nightly linetable changes

### DIFF
--- a/src/ir/ir.jl
+++ b/src/ir/ir.jl
@@ -1,9 +1,21 @@
-using Base.IRShow: LineInfoNode
 import Base: push!, insert!, getindex, setindex!, iterate, length
 
 # We have our own versions of these in order to
 # (1) be more robust to Base IR changes, and
 # (2) make sure that mistakes/bugs do not cause bad LLVM IR.
+
+"""
+    LineInfoNode(file::Symbol, line::Int32, [inlined_at::Int32])
+
+Represents line information about a statement; Inlined statements has a non-zero
+`inlined_at` which represents the "parent" location in the linetable array.
+"""
+struct LineInfoNode
+  file::Symbol
+  line::Int32
+  inlined_at::Int32
+end
+LineInfoNode(file, line) = LineInfoNode(file, line, Int32(0))
 
 struct Undefined end
 const undef = Undefined()

--- a/src/ir/ir.jl
+++ b/src/ir/ir.jl
@@ -1,4 +1,4 @@
-using Core.Compiler: LineInfoNode
+using Base.IRShow: LineInfoNode
 import Base: push!, insert!, getindex, setindex!, iterate, length
 
 # We have our own versions of these in order to

--- a/src/reflection/utils.jl
+++ b/src/reflection/utils.jl
@@ -156,7 +156,9 @@ end
 
 function update!(ci::CodeInfo, ir::Core.Compiler.IRCode)
   replace_code_newstyle!(ci, ir, length(ir.argtypes))
-  ci.inferred = false
+  @static if VERSION < v"1.12.0-DEV.15"
+    ci.inferred = false
+  end
   ci.ssavaluetypes = length(ci.code)
   slots!(ci)
   fill!(ci.slotflags, 0)


### PR DESCRIPTION
`Core.Compiler.LineInfoNode` was removed in https://github.com/JuliaLang/julia/pull/52415 but kept in `Core` for serializer compatibility reasons (see https://github.com/JuliaLang/julia/blob/e07c0f1ddbfc89ad1ac4dda7246d8ed5d0d57c19/base/boot.jl#L491).

Adaptation for IRTools is relatively straightforward in the sense that IRTools operates on untyped IR which does not contains inlined statements.

However, IRTools contains an inlining pass but it did not account for linetable information previously. In this change, I have made the choice to use the source line for all inlined statements. This can be further improved in the future by supporting stacked debuginfos.

> [!note]
> The second commit (https://github.com/FluxML/IRTools.jl/commit/cc97588d963c84aa6f3d67ac1eb6923de2a43ed4) moves the definition of `LineInfoNode` inside `IRTools` to prevent future breaking changes. But this can create a breakage for people using `IR(lines::Vector{LineInfoNode})` constructor so we may not want to include it yet or add conversions.

Closes #121 